### PR TITLE
[Feat/#27] 이미지 테이블 경로 단일 컬럼으로 수정, 이미지 업로드 기능 구현 및 리소스 핸들러 설정 추가

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
+DOCKER_REPO=marketplace-platform
+DOCKER_USER=82everywin
 MYSQL_ROOT_PASSWORD=marketplace
 MYSQL_DATABASE=marketplace
 MYSQL_USER=marketplace

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,6 +14,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+        # .gitignore에 있는 properties파일 추가
+      - name: Add prod_properties
+        run: |
+          mkdir ./src/main/resources
+          touch ./src/main/resources/application.properties
+          echo "${{ secrets.PROPERTIES }}" > ./src/main/resources/application.properties
+
+       # .gitingnore에 있는 .env파일 docker compose 실행을 위해 추가
+      - name: Add .env
+        run: echo "${{ secrets.ENV }}" > .env
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -48,11 +59,31 @@ jobs:
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPONAME }}
 
   CD:
-    needs: [CI]
+    needs: [ CI ]
 
     runs-on: ubuntu-latest
 
     steps:
+      - name: Deploy .env to EC2
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.DEPLOYMENT_HOST }}
+          username: ${{ secrets.DEPLOYMENT_USERNAME }}
+          password: ${{ secrets.DEPLOYMENT_PASSWORD }}
+          key: ${{ secrets.SSH_KEY }}
+          source: .env
+          target: /home/serverking/marketplace
+
+      - name: Deploy docker compose file
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.DEPLOYMENT_HOST }}
+          username: ${{ secrets.DEPLOYMENT_USERNAME }}
+          password: ${{ secrets.DEPLOYMENT_PASSWORD }}
+          key: ${{ secrets.SSH_KEY }}
+          source: docker-compose.yml
+          target: /home/serverking/marketplace
+
       - name: Deploy remote ssh commands using password
         uses: appleboy/ssh-action@master
         with:
@@ -63,5 +94,5 @@ jobs:
           script_stop: true
           script: |
             cd marketplace
-            chmod +x ./deploy.sh
-            ./deploy.sh
+            docker-compose pull
+            docker-compose up -d

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ bin/
 !**/src/test/**/bin/
 
 ### IntelliJ IDEA ###
+application-dev.properties
+application-prod.properties
+.env
 .idea
 *.iws
 *.iml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,12 @@
 version: '3.8'
 
 services:
-    mysql:
-      image: mysql:latest
-      container_name: mysql
-      environment:
-        MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-        MYSQL_DATABASE: ${MYSQL_DATABASE}
-        MYSQL_USER: ${MYSQL_USER}
-        MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      ports:
-        - "3306:3306"
-      volumes:
-        - mysql_data:/var/lib/mysql
-
-
-volumes:
-    mysql_data:
-
+  springboot:
+    container_name: marketplace
+    image: ${DOCKER_USER}/${DOCKER_REPO}:marketplace-server  # Docker Hub에서 가져올 이미지
+    volumes:
+      - /home/serverking/marketplace:/app/image
+    ports:
+      - "8088:8080"
+    environment:
+      TZ: "Asia/Seoul"

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+
+services:
+    mysql:
+      image: mysql:latest
+      container_name: mysql
+      environment:
+        MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+        MYSQL_DATABASE: ${MYSQL_DATABASE}
+        MYSQL_USER: ${MYSQL_USER}
+        MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      ports:
+        - "3306:3306"
+      volumes:
+        - mysql_data:/var/lib/mysql
+
+
+volumes:
+    mysql_data:
+

--- a/src/main/java/com/appcenter/marketplace/domain/image/Image.java
+++ b/src/main/java/com/appcenter/marketplace/domain/image/Image.java
@@ -2,9 +2,9 @@ package com.appcenter.marketplace.domain.image;
 
 import com.appcenter.marketplace.domain.market.Market;
 import com.appcenter.marketplace.global.common.BaseEntity;
-import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,15 +18,15 @@ public class Image extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String uuid;
-
-    @Column(nullable = false)
-    private String folder;
-
-    @Column(name = "original_name", nullable = false)
-    private String originalName;
+    private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn( name = "market_id", nullable = false)
     private Market market;
+
+    @Builder
+    public Image(String name, Market market) {
+        this.name=name;
+        this.market = market;
+    }
 }

--- a/src/main/java/com/appcenter/marketplace/domain/image/ImageRepository.java
+++ b/src/main/java/com/appcenter/marketplace/domain/image/ImageRepository.java
@@ -1,0 +1,6 @@
+package com.appcenter.marketplace.domain.image;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image,Long> {
+}

--- a/src/main/java/com/appcenter/marketplace/domain/image/service/ImageService.java
+++ b/src/main/java/com/appcenter/marketplace/domain/image/service/ImageService.java
@@ -1,0 +1,12 @@
+package com.appcenter.marketplace.domain.image.service;
+
+import com.appcenter.marketplace.domain.market.Market;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface ImageService {
+
+    void createImage(Market market, List<MultipartFile> multipartFileList) throws IOException;
+}

--- a/src/main/java/com/appcenter/marketplace/domain/image/service/impl/ImageServiceImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/image/service/impl/ImageServiceImpl.java
@@ -26,6 +26,7 @@ public class ImageServiceImpl implements ImageService {
 
     // 이미지 리스트의 첫번째 요소를 썸네일로 설정
     @Override
+    @Transactional
     public void createImage(Market market, List<MultipartFile> multipartFileList) throws IOException {
 
         for (int i = 0; i < multipartFileList.size(); i++){

--- a/src/main/java/com/appcenter/marketplace/domain/image/service/impl/ImageServiceImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/image/service/impl/ImageServiceImpl.java
@@ -1,0 +1,50 @@
+package com.appcenter.marketplace.domain.image.service.impl;
+
+import com.appcenter.marketplace.domain.image.Image;
+import com.appcenter.marketplace.domain.image.ImageRepository;
+import com.appcenter.marketplace.domain.image.service.ImageService;
+import com.appcenter.marketplace.domain.market.Market;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class ImageServiceImpl implements ImageService {
+    private final ImageRepository imageRepository;
+
+    @Value("${image.upload.path}")
+    private String uploadFolder;
+
+    // 이미지 리스트의 첫번째 요소를 썸네일로 설정
+    @Override
+    public void createImage(Market market, List<MultipartFile> multipartFileList) throws IOException {
+
+        for (int i = 0; i < multipartFileList.size(); i++){
+            MultipartFile file = multipartFileList.get(i);
+            String imageFileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+            File uploadFile = new File(uploadFolder + imageFileName);
+
+            file.transferTo(uploadFile);
+
+            Image image= Image.builder()
+                    .name(imageFileName)
+                    .market(market)
+                    .build();
+            imageRepository.save(image);
+
+            if(i==0){
+                market.updateThumbnailPath(image.getName());
+            }
+
+        }
+    }
+}

--- a/src/main/java/com/appcenter/marketplace/domain/market/Market.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/Market.java
@@ -67,4 +67,7 @@ public class Market extends BaseEntity {
         this.address = marketUpdateReqDto.getAddress();
         this.category= category;
     }
+    public void updateThumbnailPath(String thumbnail){
+        this.thumbnail= thumbnail;
+    }
 }

--- a/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketOwnerController.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketOwnerController.java
@@ -8,6 +8,7 @@ import com.appcenter.marketplace.global.common.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,7 +25,7 @@ public class MarketOwnerController {
     private final MarketOwnerService marketOwnerService;
 
     @Operation(summary = "사장님 매장 생성", description = "사장님이 1개의 매장을 생성합니다.")
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommonResponse<MarketResDto>> createMarket(
             @RequestPart(value = "jsonData") @Valid MarketCreateReqDto marketCreateReqDto,
             @RequestPart(value = "files") List<MultipartFile> multipartFileList) throws IOException {

--- a/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketOwnerController.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketOwnerController.java
@@ -24,7 +24,8 @@ import static com.appcenter.marketplace.global.common.StatusCode.*;
 public class MarketOwnerController {
     private final MarketOwnerService marketOwnerService;
 
-    @Operation(summary = "사장님 매장 생성", description = "사장님이 1개의 매장을 생성합니다.")
+    @Operation(summary = "사장님 매장 생성", description = "사장님이 1개의 매장을 생성합니다. <br>" +
+            "이미지를 가져오려면 /image/{image.name}을 fetch하면 됩니다.")
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommonResponse<MarketResDto>> createMarket(
             @RequestPart(value = "jsonData") @Valid MarketCreateReqDto marketCreateReqDto,

--- a/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketOwnerController.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketOwnerController.java
@@ -10,6 +10,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
 
 import static com.appcenter.marketplace.global.common.StatusCode.*;
 
@@ -21,10 +25,12 @@ public class MarketOwnerController {
 
     @Operation(summary = "사장님 매장 생성", description = "사장님이 1개의 매장을 생성합니다.")
     @PostMapping
-    public ResponseEntity<CommonResponse<MarketResDto>> createMarket(@RequestBody @Valid MarketCreateReqDto marketCreateReqDto){
+    public ResponseEntity<CommonResponse<MarketResDto>> createMarket(
+            @RequestPart(value = "jsonData") @Valid MarketCreateReqDto marketCreateReqDto,
+            @RequestPart(value = "files") List<MultipartFile> multipartFileList) throws IOException {
         return ResponseEntity
                 .status(MARKET_CREATE.getStatus())
-                .body(CommonResponse.from(MARKET_CREATE.getMessage(),marketOwnerService.createMarket(marketCreateReqDto)));
+                .body(CommonResponse.from(MARKET_CREATE.getMessage(),marketOwnerService.createMarket(marketCreateReqDto,multipartFileList)));
     }
 
     @Operation(summary = "사장님 매장 정보 수정", description = "사장님이 생성한 매장 정보를 수정합니다.")

--- a/src/main/java/com/appcenter/marketplace/domain/market/service/MarketOwnerService.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/service/MarketOwnerService.java
@@ -3,10 +3,14 @@ package com.appcenter.marketplace.domain.market.service;
 import com.appcenter.marketplace.domain.market.dto.req.MarketCreateReqDto;
 import com.appcenter.marketplace.domain.market.dto.req.MarketUpdateReqDto;
 import com.appcenter.marketplace.domain.market.dto.res.MarketResDto;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
 
 public interface MarketOwnerService {
 
-    MarketResDto createMarket(MarketCreateReqDto marketCreateReqDto);
+    MarketResDto createMarket(MarketCreateReqDto marketCreateReqDto, List<MultipartFile> multiPartFileList) throws IOException;
 
     MarketResDto updateMarket(MarketUpdateReqDto marketUpdateReqDto, Long marketId);
 

--- a/src/main/java/com/appcenter/marketplace/domain/market/service/impl/MarketOwnerServiceImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/service/impl/MarketOwnerServiceImpl.java
@@ -2,6 +2,7 @@ package com.appcenter.marketplace.domain.market.service.impl;
 
 import com.appcenter.marketplace.domain.category.Category;
 import com.appcenter.marketplace.domain.category.CategoryRepository;
+import com.appcenter.marketplace.domain.image.service.ImageService;
 import com.appcenter.marketplace.domain.market.Market;
 import com.appcenter.marketplace.domain.market.MarketRepository;
 import com.appcenter.marketplace.domain.market.dto.req.MarketCreateReqDto;
@@ -13,8 +14,13 @@ import com.appcenter.marketplace.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
-import static com.appcenter.marketplace.global.common.StatusCode.*;
+import java.io.IOException;
+import java.util.List;
+
+import static com.appcenter.marketplace.global.common.StatusCode.CATEGORY_NOT_EXIST;
+import static com.appcenter.marketplace.global.common.StatusCode.MARKET_NOT_EXIST;
 
 @Transactional(readOnly = true)
 @Service
@@ -22,13 +28,15 @@ import static com.appcenter.marketplace.global.common.StatusCode.*;
 public class MarketOwnerServiceImpl implements MarketOwnerService {
     private final MarketRepository marketRepository;
     private final CategoryRepository categoryRepository;
+    private final ImageService imageService;
 
 
     @Override
     @Transactional
-    public MarketResDto createMarket(MarketCreateReqDto marketCreateReqDto) {
+    public MarketResDto createMarket(MarketCreateReqDto marketCreateReqDto, List<MultipartFile> multipartFileList) throws IOException {
         Category category=findCategoryByMajor(marketCreateReqDto.getMajor());
         Market market=marketRepository.save(marketCreateReqDto.toEntity(category));
+        imageService.createImage(market,multipartFileList);
         return MarketResDto.from(market);
     }
 

--- a/src/main/java/com/appcenter/marketplace/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/member/service/impl/MemberServiceImpl.java
@@ -5,12 +5,14 @@ import com.appcenter.marketplace.domain.member.MemberRepository;
 import com.appcenter.marketplace.domain.member.dto.req.MemberLoginReqDto;
 import com.appcenter.marketplace.domain.member.dto.res.MemberLoginResDto;
 import com.appcenter.marketplace.domain.member.service.MemberService;
-import static com.appcenter.marketplace.global.common.StatusCode.*;
 import com.appcenter.marketplace.global.exception.CustomException;
 import com.appcenter.marketplace.global.oracleRepository.InuLoginRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.appcenter.marketplace.global.common.StatusCode.INVALID_STUDENT_ID;
+import static com.appcenter.marketplace.global.common.StatusCode.UNAUTHORIZED_LOGIN_ERROR;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +41,7 @@ public class MemberServiceImpl implements MemberService {
         }catch (Exception e){
             throw new CustomException(INVALID_STUDENT_ID);
         }
+
     }
 
 }

--- a/src/main/java/com/appcenter/marketplace/global/common/StatusCode.java
+++ b/src/main/java/com/appcenter/marketplace/global/common/StatusCode.java
@@ -28,6 +28,8 @@ public enum StatusCode {
     /* 400 BAD_REQUEST : 잘못된 요청 */
     INPUT_VALUE_INVALID(BAD_REQUEST,"유효하지 않은 입력입니다."),
     INVALID_STUDENT_ID(BAD_REQUEST,"유효하지 않은 학번입니다."),
+    MULTI_PART_FILE_INVALID(BAD_REQUEST,"유효하지 않은 MultiPartFile입니다."),
+    FILE_INVALID(BAD_REQUEST,"파일 저장 중 오류가 발생했습니다."),
 
     /* 401 UNAUTHORIZED : 비인증 사용자 */
     UNAUTHORIZED_LOGIN_ERROR(UNAUTHORIZED, "학번 또는 비밀번호가 올바르지 않습니다."),

--- a/src/main/java/com/appcenter/marketplace/global/config/ImageConfig.java
+++ b/src/main/java/com/appcenter/marketplace/global/config/ImageConfig.java
@@ -1,0 +1,28 @@
+package com.appcenter.marketplace.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+
+
+// MVC 기능을 커스터마이징 하고 확장하기 위한 설정
+@Configuration
+public class ImageConfig implements WebMvcConfigurer{
+
+    @Value("${image.upload.path}")
+    private String uploadFolder;
+
+    //외부 폴더에 있는 이미지에 접근하기 위한 설정, handler url로 요청시 접근 가능하다.
+    //프론트는 폴더이름을 몰라도 /image/**로 요청하면 외부 폴더에 매핑되서 접근가능하다.
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/image/**")
+                // 윈도우는 file:/, 리눅스는 file:/// 이다. 도커에서 실행할경우 file:/이다.
+                // 리눅스에선 URI형식이 첫 번째 /는 URI의 스킴을 나타내고, 두 번째 /는 리눅스의 파일 시스템 루트를 나타낸다.
+                .addResourceLocations("file:"+ uploadFolder);
+
+    }
+
+}

--- a/src/main/java/com/appcenter/marketplace/global/config/ImageConfig.java
+++ b/src/main/java/com/appcenter/marketplace/global/config/ImageConfig.java
@@ -1,18 +1,25 @@
 package com.appcenter.marketplace.global.config;
 
+import com.appcenter.marketplace.global.swagger.OctetStreamReadMsgConverter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
 
 
 // MVC 기능을 커스터마이징 하고 확장하기 위한 설정
 @Configuration
+@RequiredArgsConstructor
 public class ImageConfig implements WebMvcConfigurer{
 
     @Value("${image.upload.path}")
     private String uploadFolder;
+    private final OctetStreamReadMsgConverter octetStreamReadMsgConverter;
+
 
     //외부 폴더에 있는 이미지에 접근하기 위한 설정, handler url로 요청시 접근 가능하다.
     //프론트는 폴더이름을 몰라도 /image/**로 요청하면 외부 폴더에 매핑되서 접근가능하다.
@@ -23,6 +30,12 @@ public class ImageConfig implements WebMvcConfigurer{
                 // 리눅스에선 URI형식이 첫 번째 /는 URI의 스킴을 나타내고, 두 번째 /는 리눅스의 파일 시스템 루트를 나타낸다.
                 .addResourceLocations("file:"+ uploadFolder);
 
+    }
+
+    // Spring이 기본적으로 생성하는 HttpMessageConverter 리스트에 추가로 생성해 줄 커스텀 메시지 컨버터를 추가해주기 위한 설정 파일.
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.add(octetStreamReadMsgConverter);
     }
 
 }

--- a/src/main/java/com/appcenter/marketplace/global/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/appcenter/marketplace/global/exception/ExceptionControllerAdvice.java
@@ -5,8 +5,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
-import static com.appcenter.marketplace.global.common.StatusCode.INPUT_VALUE_INVALID;
+import java.io.IOException;
+
+import static com.appcenter.marketplace.global.common.StatusCode.*;
 
 @RestControllerAdvice
 public class ExceptionControllerAdvice {
@@ -23,6 +26,26 @@ public class ExceptionControllerAdvice {
                 .validationErrors(ErrorResponse.ValidationError.from(e.getBindingResult()))
                 .build();
         return ResponseEntity.status(INPUT_VALUE_INVALID.getStatus())
+                .body(errorResponse);
+    }
+
+    // requestPart로 받은 multiPartFile이 null이면 발생하는 예외
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestPartException(MissingServletRequestPartException e) {
+        ErrorResponse errorResponse= ErrorResponse.builder()
+                .message(MULTI_PART_FILE_INVALID.getMessage())
+                .build();
+        return ResponseEntity.status(MULTI_PART_FILE_INVALID.getStatus())
+                .body(errorResponse);
+    }
+
+    // 이미지 저장 시 생길 수 있는 예외, 주로 파일 입출력 오류 시 나타난다.
+    @ExceptionHandler(IOException.class)  // 특정 예외를 처리
+    public ResponseEntity<ErrorResponse> handleIOException(IOException e) {
+        ErrorResponse errorResponse=ErrorResponse.builder()
+                .message(FILE_INVALID.getMessage())
+                .build();
+        return ResponseEntity.status(FILE_INVALID.getStatus())
                 .body(errorResponse);
     }
 

--- a/src/main/java/com/appcenter/marketplace/global/oracleRepository/InuLoginRepository.java
+++ b/src/main/java/com/appcenter/marketplace/global/oracleRepository/InuLoginRepository.java
@@ -26,5 +26,6 @@ public class InuLoginRepository {
             log.info("데이터베이스 연결 오류 메시지 : {}",e.getMessage());
             return false;
         }
+
     }
 }

--- a/src/main/java/com/appcenter/marketplace/global/swagger/OctetStreamReadMsgConverter.java
+++ b/src/main/java/com/appcenter/marketplace/global/swagger/OctetStreamReadMsgConverter.java
@@ -1,0 +1,43 @@
+package com.appcenter.marketplace.global.swagger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+
+/*
+    @requestPart 어노테이션은 content-type이 multipart-form인 요청에서 JSON과 파일 데이터를 동시에 객체로 만들어주는 어노테이션이다.
+    하지만 content-type이 multipart-form 하나이므로 json데이터는 content-type이 null로 누락이 된다.
+    content-type이 null이면 application/octet-stream 타입으로 지정해버린다.
+    따라서 application/octet-stream을 다뤄주는 HttpMessageConverter를 추가하면 된다
+ */
+@Component
+// application/octet-stream 타입의 Http 메시지에 대한 읽기 작업(Http 메시지 -> Java class)을 수행할 커스텀 메시지 컨버터.
+// 즉, multipart-form 요청에서 JSON 데이터를 받아올 수 있게 된다.
+public class OctetStreamReadMsgConverter extends AbstractJackson2HttpMessageConverter {
+    @Autowired
+    public OctetStreamReadMsgConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    // 기존 application/octet-stream 타입을 쓰기로 다루는 메시지 컨버터가 이미 존재 (ByteArrayHttpMessageConverter)
+    // 따라서 해당 컨버터는 쓰기 작업에는 이용하면 안됨
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -23,3 +23,5 @@ oracle.datasource.driver-class-name=oracle.jdbc.OracleDriver
 oracle.datasource.jdbc-url=jdbc:oracle:thin:@//117.16.191.204:2521/INUDB
 oracle.datasource.username=LNK_MAP
 oracle.datasource.password=map0115
+
+image.upload.path=/app/image/

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,5 +1,3 @@
-server.port=8088
-
 swagger.server-url=https://marketplace.inuappcenter.kr
 
 # ???? ?? ?? ??

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -25,3 +25,5 @@ oracle.datasource.driver-class-name=oracle.jdbc.OracleDriver
 oracle.datasource.jdbc-url=jdbc:oracle:thin:@//117.16.191.204:2521/INUDB
 oracle.datasource.username=LNK_MAP
 oracle.datasource.password=map0115
+
+image.upload.path=/app/image/


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 구현
- [ ] 문서화
- [x] 리팩토링
- [ ] 이슈해결(오류해결)
- [x] 의존성, 환경 변수, 빌드 관련 환경설정 


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
<br>
Closes #27 
Closes #29 
<br>


## 💻작업사항
필요시 실행결과 스크린샷 첨부
<br>
<br>


## 💡작성한 이슈 외에 작업한 사항
- (기존) 이미지 테이블에서 UUID, folder, file명 등 요소들로 경로 구성 -> (수정) 단일 컬럼으로 UUID_file명 저장
- 리소스 핸들러 설정을 통해 , 사용자는 파일 시스템의 구조를 알 필요 없이 HTTP 요청을 통해 파일에 접근할 수 있다.
예시) GET /image/UUID_file   ->  /home/marketplace/image/UUID_file 접근
<br>

## 🩷 Approve 하기 전 확인해주세요!
- [x] 배포하기 전 dockerfile  or docker-compose에서 properties 파일의 컨테이너 경로와 호스트 디렉토리 경로 마운트 필요 

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
