### PR TITLE
[Refactor/#38] 이미지 테이블 sequence 컬럼 unique 제약조건으로 인한 이미지 순서 변경 로직 보완

### DIFF
--- a/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketOwnerController.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketOwnerController.java
@@ -48,7 +48,8 @@ public class MarketOwnerController {
 
     @Operation(summary = "사장님 매장 이미지 수정", description = "매장의 이미지를 추가,삭제 및 순서 변경을 합니다. <br>" +
             "jsonData는 삭제할 이미지 id 리스트, 순서 변경할 Map<이미지id,순서order>, 추가할 이미지의 순서 리스트입니다. <br>" +
-            "images는 추가할 이미지 리스트입니다. 기존 이미지는 안주셔도 됩니다.")
+            "images는 추가할 이미지 리스트입니다. 기존 이미지는 안주셔도 됩니다. <br>" +
+            "예시) 추가할 이미지의 순서 리스트가 [2,4] 이면, 이미지 파일은 2개여야하고, 첫번 째 사진은 순서 2가 부여됩니다. 두번 째 사진은 4가 부여됩니다.")
     @PutMapping(value = "/images",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CommonResponse<MarketResDto>> updateMarket(
             @RequestPart(value = "jsonData") MarketImageUpdateReqDto marketImageUpdateReqDto,

--- a/src/main/java/com/appcenter/marketplace/domain/market/dto/req/MarketImageUpdateReqDto.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/dto/req/MarketImageUpdateReqDto.java
@@ -10,7 +10,7 @@ import java.util.Map;
 @NoArgsConstructor
 public class MarketImageUpdateReqDto {
     private List<Long> deletedImageIds; // 삭제할 이미지 ID 리스트
-    private Map<Long, Integer> changedOrders; // 변경된 순서 (id와 Order를 Map으로 처리)
-    private List<Integer> addedImageOrders; // 추가된 이미지의 순서 리스트 (순서 번호)
+    private Map<Long, Integer> changedSequences; // 변경된 순서 (id와 sequence를 Map으로 처리)
+    private List<Integer> addedImageSequences; // 추가된 이미지의 순서 리스트 (순서 번호)
 
 }

--- a/src/main/java/com/appcenter/marketplace/global/common/StatusCode.java
+++ b/src/main/java/com/appcenter/marketplace/global/common/StatusCode.java
@@ -30,6 +30,7 @@ public enum StatusCode {
     INPUT_VALUE_INVALID(BAD_REQUEST,"유효하지 않은 입력입니다."),
     INVALID_STUDENT_ID(BAD_REQUEST,"유효하지 않은 학번입니다."),
     MULTI_PART_FILE_INVALID(BAD_REQUEST,"MultiPartFile이 존재하지 않습니다"),
+    MULTI_PART_FILE_SEQUENCE_INVALID(BAD_REQUEST,"MultipartFile과 순서 리스트의 개수가 맞지 않습니다."),
     FILE_SAVE_INVALID(BAD_REQUEST,"파일 저장 중 오류가 발생했습니다."),
     FILE_DELETE_INVALID(BAD_REQUEST,"파일 삭제 중 오류가 발생했습니다."),
     DATA_INTEGRITY_VIOLATION(BAD_REQUEST,"이미 존재하는 값이거나 필수 필드에 null이 있습니다."),


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 구현
- [ ] 문서화
- [x] 리팩토링
- [ ] 이슈해결(오류해결)
- [ ] 의존성, 환경 변수, 빌드 관련 환경설정 


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
<br>
close #38 
<br>


## 💻작업사항
필요시 실행결과 스크린샷 첨부
<br>
<br>


## 💡작성한 이슈 외에 작업한 사항

- 이미지 테이블 순서 컬럼 sequence를 unique로 변경함으로 써 중복을 없앰.

- 이미지 서비스 로직 중 예외가 발생하면 롤백이 되지만 파일 시스템은 롤백이 안됨. 따라서 엔티티와 파일의 상태가 일치하지 않는 경우 발생.  -> (기존) 파일 시스템 작업 후 엔티티 crud -> (현재) 엔티티 crud 후 파일 시스템 작업

- querydsl transfrom() 메서드 사용하기 위한 querydsl config 수정

- 매장 이미지 수정 api에서 multipart required=false로 변경

- 데이터베이스 무결성 제약조건 위반 예외처리 추가
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
