### PR TITLE
[Issue/#70] 가장 많은 찜 순 매장 페이징 조회 관련 멤버 찜 여부 추가 & 데이터 건너 뜀 방지 조건 추가

### DIFF
--- a/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketController.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketController.java
@@ -74,12 +74,14 @@ public class MarketController {
     @GetMapping("/favorite")
     public ResponseEntity<CommonResponse<MarketPageRes<FavoriteMarketRes>>> getTopFavoriteMarketList(
             @RequestParam Long memberId,
+            @Parameter(description = "페이지의 마지막 marketId")
+            @RequestParam(required = false, name = "lastMarketId") Long marketId,
             @Parameter(description = "페이지의 마지막 favoriteCount")
             @RequestParam(required = false, name = "lastFavoriteCount") Long count,
             @RequestParam(defaultValue = "10", name = "pageSize") Integer size) {
         return ResponseEntity
                 .ok(CommonResponse.from(MARKET_FOUND.getMessage()
-                        ,marketService.getFavoriteMarketPage(memberId,count,size)));
+                        ,marketService.getFavoriteMarketPage(memberId,marketId,count,size)));
     }
 
     @Operation(summary = "찜 수가 가장 많은 매장 TOP 조회",

--- a/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketController.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketController.java
@@ -35,7 +35,7 @@ public class MarketController {
 
     // size가 null로 들어올 시 기본 값을 지정해주기 위해 integer로 값을 받아온다.
     @Operation(summary = "전체 매장 조회",
-            description = "처음 요청 시, pageSize만 필요합니다. 기본값은 5입니다. <br>" +
+            description = "처음 요청 시, pageSize만 필요합니다. 기본값은 10입니다. <br>" +
                     "카테고리 별 매장을 조회하시려면 category도 필요합니다. <br>" +
                     "최신순으로 보여줍니다.")
     @GetMapping
@@ -44,7 +44,7 @@ public class MarketController {
             @Parameter(description = "페이지의 마지막 marketId")
             @RequestParam(required = false, name = "lastPageIndex") Long marketId,
             @RequestParam(required = false, name = "category") String major,
-            @RequestParam(defaultValue = "5", name = "pageSize") Integer size)
+            @RequestParam(defaultValue = "10", name = "pageSize") Integer size)
     {
         return ResponseEntity
                 .ok(CommonResponse.from(MARKET_FOUND.getMessage()
@@ -53,7 +53,7 @@ public class MarketController {
 
     @Operation(summary = "자신이 찜한 매장 조회",
             description = "자신이 찜한 매장 정보 리스트를 반환합니다. <br>" +
-                    "처음 요청 시엔 pageSize만 필요합니다.기본값은 5입니다. <br>" +
+                    "처음 요청 시엔 pageSize만 필요합니다.기본값은 10입니다. <br>" +
                     "JWT 구현 전 까지는 memberId를 추가해야합니다. <br>" +
                     "최신 찜 순으로 보여줍니다.")
     @GetMapping("/my-favorite")
@@ -61,7 +61,7 @@ public class MarketController {
             @RequestParam Long memberId,
             @Parameter(description = "페이지의 마지막 favoriteModifiedAt (e.g. 2024-11-25 11:19:26.378948 )")
             @RequestParam(required = false, name = "lastModifiedAt") LocalDateTime lastModifiedAt,
-            @RequestParam(defaultValue = "5", name = "pageSize") Integer size) {
+            @RequestParam(defaultValue = "10", name = "pageSize") Integer size) {
         return ResponseEntity
                 .ok(CommonResponse.from(MARKET_FOUND.getMessage()
                         ,marketService.getMyFavoriteMarketPage(memberId,lastModifiedAt,size)));
@@ -69,14 +69,14 @@ public class MarketController {
 
     @Operation(summary = "찜 수가 가장 많은 매장 더보기 조회",
             description = "사용자들이 가장 많이 찜한 매장 정보 리스트를 반환합니다. <br>" +
-                    "처음 요청 시엔 pageSize만 필요합니다. 기본값은 5입니다. <br>" +
+                    "처음 요청 시엔 pageSize만 필요합니다. 기본값은 10입니다. <br>" +
                     "찜 수가 가장 많은 순으로 보여줍니다.")
     @GetMapping("/favorite")
     public ResponseEntity<CommonResponse<MarketPageRes<FavoriteMarketRes>>> getTopFavoriteMarketList(
             @RequestParam Long memberId,
             @Parameter(description = "페이지의 마지막 favoriteCount")
             @RequestParam(required = false, name = "lastFavoriteCount") Long count,
-            @RequestParam(defaultValue = "5", name = "pageSize") Integer size) {
+            @RequestParam(defaultValue = "10", name = "pageSize") Integer size) {
         return ResponseEntity
                 .ok(CommonResponse.from(MARKET_FOUND.getMessage()
                         ,marketService.getFavoriteMarketPage(memberId,count,size)));
@@ -84,10 +84,10 @@ public class MarketController {
 
     @Operation(summary = "찜 수가 가장 많은 매장 TOP 조회",
             description = "사용자들이 가장 많이 찜한 매장 Top을 반환합니다. <br>" +
-                    "size의 기본값은 5입니다.")
+                    "size의 기본값은 10입니다.")
     @GetMapping("/top-favorite")
     public ResponseEntity<CommonResponse<List<TopFavoriteMarketRes>>> getTopFavoriteMarketList(
-            @RequestParam(defaultValue = "5", name = "size") Integer size) {
+            @RequestParam(defaultValue = "10", name = "size") Integer size) {
         return ResponseEntity
                 .ok(CommonResponse.from(MARKET_FOUND.getMessage()
                         ,marketService.getTopFavoriteMarkets(size)));

--- a/src/main/java/com/appcenter/marketplace/domain/market/repository/MarketRepositoryCustom.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/repository/MarketRepositoryCustom.java
@@ -14,7 +14,7 @@ public interface MarketRepositoryCustom {
 
     public List<MyFavoriteMarketRes> findMyFavoriteMarketList(Long memberId, LocalDateTime lastModifiedAt, Integer size);
 
-    public List<FavoriteMarketRes> findFavoriteMarketList(Long memberId, Long count, Integer size);
+    public List<FavoriteMarketRes> findFavoriteMarketList(Long memberId,Long marketId, Long count, Integer size);
 
     public List<TopFavoriteMarketRes> findTopFavoriteMarkets(Integer size);
 

--- a/src/main/java/com/appcenter/marketplace/domain/market/service/MarketService.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/service/MarketService.java
@@ -13,7 +13,7 @@ public interface MarketService {
 
     MarketPageRes<MyFavoriteMarketRes> getMyFavoriteMarketPage(Long memberId, LocalDateTime lastModifiedAt, Integer size);
 
-    MarketPageRes<FavoriteMarketRes> getFavoriteMarketPage(Long memberId, Long count, Integer size);
+    MarketPageRes<FavoriteMarketRes> getFavoriteMarketPage(Long memberId, Long marketId, Long count, Integer size);
     List<TopFavoriteMarketRes> getTopFavoriteMarkets(Integer size);
 
     List<TopLatestCouponRes> getTopLatestCoupons(Integer size);

--- a/src/main/java/com/appcenter/marketplace/domain/market/service/impl/MarketServiceImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/service/impl/MarketServiceImpl.java
@@ -58,8 +58,8 @@ public class MarketServiceImpl implements MarketService {
 
     // 찜 수가 가장 많은 매장 더보기 조회
     @Override
-    public MarketPageRes<FavoriteMarketRes> getFavoriteMarketPage(Long memberId, Long count, Integer size) {
-        List<FavoriteMarketRes> favoriteMarketResList = marketRepository.findFavoriteMarketList(memberId, count, size);
+    public MarketPageRes<FavoriteMarketRes> getFavoriteMarketPage(Long memberId, Long marketId, Long count, Integer size) {
+        List<FavoriteMarketRes> favoriteMarketResList = marketRepository.findFavoriteMarketList(memberId, marketId, count, size);
 
         return checkNextPageAndReturn(favoriteMarketResList, size);
     }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 구현
- [x] 문서화
- [x] 리팩토링
- [x] 이슈해결(오류해결)
- [ ] 의존성, 환경 변수, 빌드 관련 환경설정 


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
<br>
close #70 
<br>


## 💻작업사항
필요시 실행결과 스크린샷 첨부
<br>
![image](https://github.com/user-attachments/assets/e1bd3fff-38e9-40c0-bc44-8c411ca43a38)

<br>


## 💡작성한 이슈 외에 작업한 사항
- 매장 조회 시 default page size 5-> 10 변경
- 가장 찜 많은 순 매장 조회시 데이터 건너 뜀 방지 조건 추가
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
