### PR TITLE
[Feat/#88] 매장 검색 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0' //swagger
 	implementation 'com.oracle.database.jdbc:ojdbc11'
 	implementation 'org.springframework.boot:spring-boot-starter-validation' //유효성 검사
+	implementation group: 'org.qlrm', name: 'qlrm', version: '4.0.1' // native 쿼리를 dto에 매핑시킬 수 있는 라이브러리
 
 	// QueryDSL 설정
 	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"

--- a/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketController.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketController.java
@@ -69,6 +69,21 @@ public class MarketController {
                         ,marketService.getMarketPageByAddress(memberId, marketId, size, major, address)));
     }
 
+    @Operation(summary = "매장 검색",
+            description = "처음 요청 시, lastPageIndex는 필요하지 않습니다. <br>" +
+                    "최신순으로 보여줍니다.")
+    @GetMapping("/search")
+    public ResponseEntity<CommonResponse<MarketPageRes<MarketRes>>> searchMarket(
+            @Parameter(description = "페이지의 마지막 marketId")
+            @RequestParam(required = false, name = "lastPageIndex") Long marketId,
+            @RequestParam(defaultValue = "10", name = "pageSize") Integer size,
+            @RequestParam String name)
+    {
+        return ResponseEntity
+                .ok(CommonResponse.from(MARKET_FOUND.getMessage()
+                        ,marketService.searchMarket(marketId, size,name)));
+    }
+
     @Operation(summary = "자신이 찜한 매장 조회",
             description = "자신이 찜한 매장 정보 리스트를 반환합니다. <br>" +
                     "처음 요청 시엔 pageSize만 필요합니다.기본값은 10입니다. <br>" +

--- a/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketController.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/controller/MarketController.java
@@ -73,7 +73,7 @@ public class MarketController {
             description = "처음 요청 시, lastPageIndex는 필요하지 않습니다. <br>" +
                     "최신순으로 보여줍니다.")
     @GetMapping("/search")
-    public ResponseEntity<CommonResponse<MarketPageRes<MarketRes>>> searchMarket(
+    public ResponseEntity<CommonResponse<MarketPageRes<MarketSearchRes>>> searchMarket(
             @Parameter(description = "페이지의 마지막 marketId")
             @RequestParam(required = false, name = "lastPageIndex") Long marketId,
             @RequestParam(defaultValue = "10", name = "pageSize") Integer size,

--- a/src/main/java/com/appcenter/marketplace/domain/market/dto/res/MarketSearchRes.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/dto/res/MarketSearchRes.java
@@ -1,0 +1,22 @@
+package com.appcenter.marketplace.domain.market.dto.res;
+
+import lombok.Getter;
+
+@Getter
+public class MarketSearchRes {
+    private final Long marketId;
+    private final String name;
+    private final String description;
+    private final String address;
+    private final String thumbnail;
+    private final Boolean isNewCoupon;
+
+    public MarketSearchRes(Long marketId, String name, String description, String address, String thumbnail, Boolean isNewCoupon) {
+        this.marketId = marketId;
+        this.name = name;
+        this.description = description;
+        this.address = address;
+        this.thumbnail = thumbnail;
+        this.isNewCoupon = isNewCoupon;
+    }
+}

--- a/src/main/java/com/appcenter/marketplace/domain/market/dto/res/MarketSearchRes.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/dto/res/MarketSearchRes.java
@@ -2,16 +2,18 @@ package com.appcenter.marketplace.domain.market.dto.res;
 
 import lombok.Getter;
 
+import java.math.BigInteger;
+
 @Getter
 public class MarketSearchRes {
-    private final Long marketId;
+    private final BigInteger marketId; // native query로 수동 매핑하면 mysql의 BigInteger타입으로 받아야한다.
     private final String name;
     private final String description;
     private final String address;
     private final String thumbnail;
     private final Boolean isNewCoupon;
 
-    public MarketSearchRes(Long marketId, String name, String description, String address, String thumbnail, Boolean isNewCoupon) {
+    public MarketSearchRes(BigInteger marketId, String name, String description, String address, String thumbnail, Boolean isNewCoupon) {
         this.marketId = marketId;
         this.name = name;
         this.description = description;

--- a/src/main/java/com/appcenter/marketplace/domain/market/repository/MarketRepository.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/repository/MarketRepository.java
@@ -3,7 +3,5 @@ package com.appcenter.marketplace.domain.market.repository;
 import com.appcenter.marketplace.domain.market.Market;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface MarketRepository extends JpaRepository<Market,Long>, MarketRepositoryCustom{
 }

--- a/src/main/java/com/appcenter/marketplace/domain/market/repository/MarketRepositoryCustomImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/repository/MarketRepositoryCustomImpl.java
@@ -6,8 +6,6 @@ import com.appcenter.marketplace.domain.image.dto.res.QImageRes;
 import com.appcenter.marketplace.domain.market.dto.res.*;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.Ops;
-import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
@@ -171,6 +169,7 @@ public class MarketRepositoryCustomImpl implements MarketRepositoryCustom{
                 .fetch();
     }
 
+
     // 회원이 찜한 매장 페이징 조회
     @Override
     public List<MyFavoriteMarketRes> findMyFavoriteMarketList(Long memberId, LocalDateTime lastModifiedAt, Integer size) {
@@ -253,7 +252,7 @@ public class MarketRepositoryCustomImpl implements MarketRepositoryCustom{
                 .leftJoin(favoriteMember).on(market.eq(favoriteMember.market)
                         .and(favoriteMember.isDeleted.eq(false)
                                 .and(favoriteMember.member.id.eq(memberId))))
-                .groupBy(market.id, market.name, market.thumbnail)
+                .groupBy(market.id, market.name, market.thumbnail,favoriteMember.id)
                 .orderBy(favorite.id.count().desc()) // 찜 수가 많은 순으로 정렬
                 .fetch();
     }

--- a/src/main/java/com/appcenter/marketplace/domain/market/repository/MarketRepositoryCustomImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/repository/MarketRepositoryCustomImpl.java
@@ -74,7 +74,7 @@ public class MarketRepositoryCustomImpl implements MarketRepositoryCustom{
                 .leftJoin(coupon).on(coupon.market.eq(market)
                         .and(coupon.isDeleted.eq(false))
                         .and(coupon.isHidden.eq(false))
-                        .and(coupon.createdAt.goe(LocalDateTime.now().minusDays(3)))) // 3일 전 보다 크거나 같은 쿠폰
+                        .and(coupon.createdAt.goe(LocalDateTime.now().minusDays(7)))) // 7일 전 보다 크거나 같은 쿠폰
                 .innerJoin(local).on(market.local.eq(local))
                 .innerJoin(metro).on(local.metro.eq(metro))
                 .where(ltMarketId(marketId))
@@ -102,7 +102,7 @@ public class MarketRepositoryCustomImpl implements MarketRepositoryCustom{
                 .leftJoin(coupon).on(coupon.market.eq(market)
                         .and(coupon.isDeleted.eq(false))
                         .and(coupon.isHidden.eq(false))
-                        .and(coupon.createdAt.goe(LocalDateTime.now().minusDays(3)))) // 3일 전 보다 크거나 같은 쿠폰
+                        .and(coupon.createdAt.goe(LocalDateTime.now().minusDays(7)))) // 7일 전 보다 크거나 같은 쿠폰
                 .innerJoin(category).on(market.category.eq(category))
                 .innerJoin(local).on(market.local.eq(local))
                 .innerJoin(metro).on(local.metro.eq(metro))
@@ -130,7 +130,7 @@ public class MarketRepositoryCustomImpl implements MarketRepositoryCustom{
                 .leftJoin(coupon).on(coupon.market.eq(market)
                         .and(coupon.isDeleted.eq(false))
                         .and(coupon.isHidden.eq(false))
-                        .and(coupon.createdAt.goe(LocalDateTime.now().minusDays(3)))) // 3일 전 보다 크거나 같은 쿠폰
+                        .and(coupon.createdAt.goe(LocalDateTime.now().minusDays(7)))) // 7일 전 보다 크거나 같은 쿠폰
                 .innerJoin(local).on(market.local.eq(local)
                         .and(market.local.id.eq(localId)))
                 .innerJoin(metro).on(local.metro.eq(metro))
@@ -158,7 +158,7 @@ public class MarketRepositoryCustomImpl implements MarketRepositoryCustom{
                 .leftJoin(coupon).on(coupon.market.eq(market)
                         .and(coupon.isDeleted.eq(false))
                         .and(coupon.isHidden.eq(false))
-                        .and(coupon.createdAt.goe(LocalDateTime.now().minusDays(3)))) // 3일 전 보다 크거나 같은 쿠폰
+                        .and(coupon.createdAt.goe(LocalDateTime.now().minusDays(7)))) // 7일 전 보다 크거나 같은 쿠폰
                 .innerJoin(category).on(market.category.eq(category))
                 .innerJoin(local).on(market.local.eq(local)
                         .and(market.local.id.eq(localId)))
@@ -190,7 +190,7 @@ public class MarketRepositoryCustomImpl implements MarketRepositoryCustom{
                 .leftJoin(coupon).on(coupon.market.eq(market)
                         .and(coupon.isDeleted.eq(false))
                         .and(coupon.isHidden.eq(false))
-                        .and(coupon.createdAt.goe(LocalDateTime.now().minusDays(3)))) // 3일 전 보다 크거나 같은 쿠폰
+                        .and(coupon.createdAt.goe(LocalDateTime.now().minusDays(7)))) // 7일 전 보다 크거나 같은 쿠폰
                 .innerJoin(local).on(market.local.eq(local))
                 .innerJoin(metro).on(local.metro.eq(metro))
                 .where(ltFavoriteModifiedAt(lastModifiedAt)) // 회원 자신이 동시간대에 찜할 수 없으므로 lt이다.
@@ -225,7 +225,7 @@ public class MarketRepositoryCustomImpl implements MarketRepositoryCustom{
                 .leftJoin(coupon).on(coupon.market.eq(market)
                         .and(coupon.isDeleted.eq(false))
                         .and(coupon.isHidden.eq(false))
-                        .and(coupon.createdAt.goe(LocalDateTime.now().minusDays(3)))) // 3일 전 보다 크거나 같은 쿠폰
+                        .and(coupon.createdAt.goe(LocalDateTime.now().minusDays(7)))) // 7일 전 보다 크거나 같은 쿠폰
                 .innerJoin(local).on(market.local.eq(local))
                 .innerJoin(metro).on(local.metro.eq(metro))
                 .groupBy(market.id, market.name, market.description, metro.name, local.name, market.thumbnail,favoriteMember.id, coupon.id)

--- a/src/main/java/com/appcenter/marketplace/domain/market/service/MarketService.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/service/MarketService.java
@@ -13,7 +13,7 @@ public interface MarketService {
 
     MarketPageRes<MarketRes> getMarketPageByAddress(Long memberId, Long marketId, Integer size, String major, String address);
 
-    MarketPageRes<MarketRes> searchMarket(Long marketId, Integer size, String name);
+    MarketPageRes<MarketSearchRes> searchMarket(Long marketId, Integer size, String name);
 
     MarketPageRes<MyFavoriteMarketRes> getMyFavoriteMarketPage(Long memberId, LocalDateTime lastModifiedAt, Integer size);
 

--- a/src/main/java/com/appcenter/marketplace/domain/market/service/MarketService.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/service/MarketService.java
@@ -13,6 +13,8 @@ public interface MarketService {
 
     MarketPageRes<MarketRes> getMarketPageByAddress(Long memberId, Long marketId, Integer size, String major, String address);
 
+    MarketPageRes<MarketRes> searchMarket(Long marketId, Integer size, String name);
+
     MarketPageRes<MyFavoriteMarketRes> getMyFavoriteMarketPage(Long memberId, LocalDateTime lastModifiedAt, Integer size);
 
     MarketPageRes<FavoriteMarketRes> getFavoriteMarketPage(Long memberId, Long marketId, Long count, Integer size);

--- a/src/main/java/com/appcenter/marketplace/domain/market/service/impl/MarketServiceImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/service/impl/MarketServiceImpl.java
@@ -78,6 +78,9 @@ public class MarketServiceImpl implements MarketService {
 
     @Override
     public MarketPageRes<MarketSearchRes> searchMarket(Long marketId, Integer size, String name) {
+        if(name.length()<2)
+            throw new CustomException(MARKET_SEARCH_NAME_INVALID);
+
         StringBuffer sb = new StringBuffer();
 
         // SELECT 절

--- a/src/main/java/com/appcenter/marketplace/domain/market/service/impl/MarketServiceImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/service/impl/MarketServiceImpl.java
@@ -9,7 +9,9 @@ import com.appcenter.marketplace.global.common.Major;
 import com.appcenter.marketplace.global.common.StatusCode;
 import com.appcenter.marketplace.global.exception.CustomException;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
+import org.qlrm.mapper.JpaResultMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -75,8 +77,56 @@ public class MarketServiceImpl implements MarketService {
     }
 
     @Override
-    public MarketPageRes<MarketRes> searchMarket(Long marketId, Integer size, String name) {
-        return null;
+    public MarketPageRes<MarketSearchRes> searchMarket(Long marketId, Integer size, String name) {
+        StringBuffer sb = new StringBuffer();
+
+        // SELECT 절
+        sb.append("SELECT ")
+                .append("market.id AS id, ")
+                .append("market.name AS name, ")
+                .append("market.description AS description, ")
+                .append("CONCAT(metropolitan_government.name, ' ', local_government.name) AS location, ")
+                .append("market.thumbnail AS thumbnail, ")
+                .append("(coupon.id IS NOT NULL) AS has_coupon ");
+
+        // FROM 절
+        sb.append("FROM market ")
+                .append("LEFT JOIN coupon ")
+                .append("ON coupon.market_id = market.id ")
+                .append("AND coupon.is_deleted = FALSE ")
+                .append("AND coupon.is_hidden = FALSE ")
+                .append("AND coupon.created_at >= NOW() - INTERVAL 7 DAY ")
+                .append("INNER JOIN local_government ")
+                .append("ON market.local_government_id = local_government.id ")
+                .append("INNER JOIN metropolitan_government ")
+                .append("ON local_government.metropolitan_government_id = metropolitan_government.id ");
+
+        // WHERE 절
+        sb.append("WHERE MATCH(market.name) AGAINST(:name IN NATURAL LANGUAGE MODE) ");
+
+        // marketId 조건 추가
+        if (marketId != null) {
+            sb.append("AND market.id < :marketId ");
+        }
+
+        // ORDER BY 및 LIMIT
+        sb.append("ORDER BY market.id DESC ")
+                .append("LIMIT :size;");
+
+        Query query = entityManager.createNativeQuery(sb.toString())
+                .setParameter("name", name)
+                .setParameter("size", size+1);
+
+        // marketId가 null이 아닐 경우 두 번째 파라미터 설정
+        if (marketId != null) {
+            query.setParameter("marketId", marketId);
+        }
+
+        // qlrm을 사용한 결과 매핑
+        JpaResultMapper resultMapper = new JpaResultMapper();
+        List<MarketSearchRes> marketSearchResDtoList= resultMapper.list(query, MarketSearchRes.class);
+
+        return checkNextPageAndReturn(marketSearchResDtoList, size);
     }
 
     // 자신이 찜한 매장 리스트 조회

--- a/src/main/java/com/appcenter/marketplace/domain/market/service/impl/MarketServiceImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/market/service/impl/MarketServiceImpl.java
@@ -8,6 +8,7 @@ import com.appcenter.marketplace.domain.market.service.MarketService;
 import com.appcenter.marketplace.global.common.Major;
 import com.appcenter.marketplace.global.common.StatusCode;
 import com.appcenter.marketplace.global.exception.CustomException;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,7 @@ import static com.appcenter.marketplace.global.common.StatusCode.*;
 public class MarketServiceImpl implements MarketService {
     private final MarketRepository marketRepository;
     private final LocalRepository localRepository;
+    private final EntityManager entityManager;
 
 
     // 매장 상세 정보 조회
@@ -70,6 +72,11 @@ public class MarketServiceImpl implements MarketService {
         } else throw new CustomException(CATEGORY_NOT_EXIST);
 
         return checkNextPageAndReturn(marketResList, size);
+    }
+
+    @Override
+    public MarketPageRes<MarketRes> searchMarket(Long marketId, Integer size, String name) {
+        return null;
     }
 
     // 자신이 찜한 매장 리스트 조회

--- a/src/main/java/com/appcenter/marketplace/global/common/StatusCode.java
+++ b/src/main/java/com/appcenter/marketplace/global/common/StatusCode.java
@@ -43,6 +43,7 @@ public enum StatusCode {
     FILE_SAVE_INVALID(BAD_REQUEST,"파일 저장 중 오류가 발생했습니다."),
     FILE_DELETE_INVALID(BAD_REQUEST,"파일 삭제 중 오류가 발생했습니다."),
     DATA_INTEGRITY_VIOLATION(BAD_REQUEST,"이미 존재하는 값이거나 필수 필드에 null이 있습니다."),
+    MARKET_SEARCH_NAME_INVALID(BAD_REQUEST,"검색어는 2글자 이상 입력해야 합니다."),
 
     /* 401 UNAUTHORIZED : 비인증 사용자 */
     UNAUTHORIZED_LOGIN_ERROR(UNAUTHORIZED, "학번 또는 비밀번호가 올바르지 않습니다."),


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 구현
- [ ] 문서화
- [x] 리팩토링
- [ ] 이슈해결(오류해결)
- [ ] 의존성, 환경 변수, 빌드 관련 환경설정 


## 연결된 issue
<br>
close #88 
<br>


## 💻작업사항
<br>
mysql의 full-text index를 이용한 매장 검색 api 구현.
n-gram parser를 이용해 매장 명과 검색어가 일치하지 않아도 매장 반환 가능
<br>


## 💡작성한 이슈 외에 작업한 사항
- 매장 리스트의 신규쿠폰 태그 여부 기간을 쿠폰 발급기간 3일 -> 7일로 변경
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
