### PR TITLE
[Feat/#115] FCM 비동기 이벤트 처리로 구현 & Retry, Recover을 통한 비동기 작업 예외처리 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/
 !**/src/test/**/bin/
 
 ### IntelliJ IDEA ###
+src/main/resources/*
 application.properties
 application-dev.properties
 application-prod.properties

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ src/main/resources/*
 application.properties
 application-dev.properties
 application-prod.properties
-local/.env
+local/**
 .idea
 *.iws
 *.iml

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'com.oracle.database.jdbc:ojdbc11'
 	implementation 'org.springframework.boot:spring-boot-starter-validation' //유효성 검사
 	implementation group: 'org.qlrm', name: 'qlrm', version: '4.0.1' // native 쿼리를 dto에 매핑시킬 수 있는 라이브러리
+	implementation 'org.springframework.retry:spring-retry'// 특정 메서드에 재시도 기능을 제공하는 라이브러리
 
 	// FCM 알림 기능을 위한 SDK
 	implementation 'com.google.firebase:firebase-admin:9.4.3'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation' //유효성 검사
 	implementation group: 'org.qlrm', name: 'qlrm', version: '4.0.1' // native 쿼리를 dto에 매핑시킬 수 있는 라이브러리
 
+	// FCM 알림 기능을 위한 SDK
+	implementation 'com.google.firebase:firebase-admin:9.4.3'
+
 	// QueryDSL 설정
 	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/src/main/generated/com/appcenter/marketplace/domain/member/QMember.java
+++ b/src/main/generated/com/appcenter/marketplace/domain/member/QMember.java
@@ -26,6 +26,8 @@ public class QMember extends EntityPathBase<Member> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
+    public final StringPath fcmToken = createString("fcmToken");
+
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
     //inherited

--- a/src/main/java/com/appcenter/marketplace/domain/coupon/service/impl/CouponOwnerServiceImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/coupon/service/impl/CouponOwnerServiceImpl.java
@@ -8,28 +8,63 @@ import com.appcenter.marketplace.domain.coupon.repository.CouponRepository;
 import com.appcenter.marketplace.domain.coupon.service.CouponOwnerService;
 import com.appcenter.marketplace.domain.market.Market;
 import com.appcenter.marketplace.domain.market.repository.MarketRepository;
+import com.appcenter.marketplace.global.common.StatusCode;
+import com.appcenter.marketplace.global.config.AsyncConfig;
 import com.appcenter.marketplace.global.exception.CustomException;
+import com.google.api.core.ApiFuture;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 import static com.appcenter.marketplace.global.common.StatusCode.*;
 
 @Transactional(readOnly = true)
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CouponOwnerServiceImpl implements CouponOwnerService {
 
     private final CouponRepository couponRepository;
     private final MarketRepository marketRepository;
+    private final FirebaseMessaging firebaseMessaging;
+    private final AsyncConfig asyncConfig;
 
     @Override
     @Transactional
     public CouponRes createCoupon(CouponReq couponReq, Long marketId) {
         Market market = findMarketById(marketId);
         Coupon coupon = couponRepository.save(couponReq.ofCreate(market));
+
+        Message message = Message.builder()
+                .setNotification(
+                        Notification.builder()
+                                .setTitle(coupon.getName())
+                                .setBody(coupon.getDescription())
+                                .build()
+                )
+                .setTopic("market-"+ market.getId())
+                .build();
+
+
+        ApiFuture<String> apiFuture= firebaseMessaging.sendAsync(message);
+
+        apiFuture.addListener(() ->{
+            try{
+                String response = apiFuture.get();
+                log.info("토픽 구독 성공: {}", response);
+            } catch (ExecutionException | InterruptedException e) {
+                log.error("토픽 구독 관련 예외 발생: {}", e.getMessage());
+                throw new CustomException(StatusCode.FCM_SEND_FAIL);
+            }
+        }, asyncConfig.getFcmExecutor());
+
         return CouponRes.toDto(coupon);
     }
 

--- a/src/main/java/com/appcenter/marketplace/domain/favorite/service/impl/FavoriteServiceImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/favorite/service/impl/FavoriteServiceImpl.java
@@ -8,38 +8,98 @@ import com.appcenter.marketplace.domain.market.repository.MarketRepository;
 import com.appcenter.marketplace.domain.member.Member;
 import com.appcenter.marketplace.domain.member.repository.MemberRepository;
 import com.appcenter.marketplace.global.common.StatusCode;
+import com.appcenter.marketplace.global.config.AsyncConfig;
 import com.appcenter.marketplace.global.exception.CustomException;
+import com.google.api.core.ApiFuture;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.TopicManagementResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 
 @Transactional(readOnly = true)
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FavoriteServiceImpl implements FavoriteService {
     private final FavoriteRepository favoriteRepository;
     private final MemberRepository memberRepository;
     private final MarketRepository marketRepository;
+    private final AsyncConfig asyncConfig;
 
     @Override
     @Transactional
     public void createOrDeleteFavorite(Long memberId, Long marketId){
         Optional<Favorite> optionalFavorite= favoriteRepository.findByMember_IdAndMarket_Id(memberId,marketId);
+        Member member= memberRepository.findById(memberId).orElseThrow(() -> new CustomException(StatusCode.MEMBER_NOT_EXIST));
+        Market market= marketRepository.findById(marketId).orElseThrow(() -> new CustomException(StatusCode.MARKET_NOT_EXIST));
+
         if(optionalFavorite.isEmpty()){
-            Member member= memberRepository.findById(memberId).orElseThrow(() -> new CustomException(StatusCode.MEMBER_NOT_EXIST));
-            Market market= marketRepository.findById(marketId).orElseThrow(() -> new CustomException(StatusCode.MARKET_NOT_EXIST));;
             Favorite favorite= Favorite.builder()
                     .isDeleted(false)
                     .member(member)
                     .market(market)
                     .build();
             favoriteRepository.save(favorite);
+
+            ApiFuture<TopicManagementResponse> apiFuture = FirebaseMessaging
+                    .getInstance()
+                    .subscribeToTopicAsync(Collections.singletonList(member.getFcmToken())
+                            ,("market-"+ market.getId().toString()));
+
+            apiFuture.addListener(() ->{
+                try{
+                    TopicManagementResponse response = apiFuture.get();
+                    log.info("토픽 구독 성공: {}", response.getSuccessCount());
+                } catch (ExecutionException | InterruptedException e) {
+                    log.error("토픽 구독 관련 예외 발생: {}", e.getMessage());
+                    throw new CustomException(StatusCode.FCM_SUBSCRIBE_FAIL);
+                }
+            }, asyncConfig.getFcmExecutor());
         }
         else{
             Favorite favorite=optionalFavorite.get();
             favorite.toggleIsDeleted();
+
+            if(favorite.getIsDeleted()==true){
+                ApiFuture<TopicManagementResponse> apiFuture = FirebaseMessaging
+                        .getInstance()
+                        .unsubscribeFromTopicAsync(Collections.singletonList(member.getFcmToken())
+                                ,("market-"+ market.getId().toString()));
+
+                apiFuture.addListener(() ->{
+                    try{
+                        TopicManagementResponse response = apiFuture.get();
+                        log.info("토픽 구독취소 성공: {}", response.getSuccessCount());
+                    } catch (ExecutionException | InterruptedException e) {
+                        log.error("토픽 구독취소 관련 예외 발생: {}", e.getMessage());
+                        throw new CustomException(StatusCode.FCM_UNSUBSCRIBE_FAIL);
+                    }
+                }, asyncConfig.getFcmExecutor());
+            }
+            else {
+                ApiFuture<TopicManagementResponse> apiFuture = FirebaseMessaging
+                        .getInstance()
+                        .subscribeToTopicAsync(Collections.singletonList(member.getFcmToken())
+                                ,("market-"+ market.getId().toString()));
+
+                apiFuture.addListener(() ->{
+                    try{
+                        TopicManagementResponse response = apiFuture.get();
+                        log.info("토픽 구독 성공: {}", response.getSuccessCount());
+                    } catch (ExecutionException | InterruptedException e) {
+                        log.error("토픽 구독 관련 예외 발생: {}", e.getMessage());
+                        throw new CustomException(StatusCode.FCM_SUBSCRIBE_FAIL);
+                    }
+                }, asyncConfig.getFcmExecutor());
+            }
+
+
         }
     }
 

--- a/src/main/java/com/appcenter/marketplace/domain/member/Member.java
+++ b/src/main/java/com/appcenter/marketplace/domain/member/Member.java
@@ -23,10 +23,14 @@ public class Member extends BaseEntity {
     @Column(name = "cheer_ticket", nullable = false)
     private Integer cheerTicket;
 
+    @Column(name = "fcm_token",nullable = true)
+    private String fcmToken;
+
     @Builder
-    public Member (Long id, Integer cheerTicket) {
+    public Member (Long id, Integer cheerTicket, String fcmToken) {
         this.id = id;
         this.cheerTicket = cheerTicket;
+        this.fcmToken= fcmToken;
     }
 
     public void reduceTicket() {

--- a/src/main/java/com/appcenter/marketplace/domain/member/Member.java
+++ b/src/main/java/com/appcenter/marketplace/domain/member/Member.java
@@ -36,5 +36,11 @@ public class Member extends BaseEntity {
     public void reduceTicket() {
         this.cheerTicket--;
     }
+
+    public void denyFcmToken() { this.fcmToken=null; }
+
+    public void permitFcmToken(String fcmToken){
+        this.fcmToken=fcmToken;
+    }
 }
 

--- a/src/main/java/com/appcenter/marketplace/domain/member/controller/MemberController.java
+++ b/src/main/java/com/appcenter/marketplace/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.appcenter.marketplace.domain.member.controller;
 
 
+import com.appcenter.marketplace.domain.member.dto.req.MemberFcmReq;
 import com.appcenter.marketplace.domain.member.dto.req.MemberLoginReq;
 import com.appcenter.marketplace.domain.member.dto.res.MemberLoginRes;
 import com.appcenter.marketplace.domain.member.service.MemberService;
@@ -12,8 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static com.appcenter.marketplace.global.common.StatusCode.MEMBER_FOUND;
-import static com.appcenter.marketplace.global.common.StatusCode.MEMBER_LOGIN_SUCCESS;
+import static com.appcenter.marketplace.global.common.StatusCode.*;
 
 @Tag(name = "[회원]", description = "[회원] 로그인 및 학번 조회")
 @RestController
@@ -35,5 +35,23 @@ public class MemberController {
     public ResponseEntity<CommonResponse<MemberLoginRes>> getMember(@PathVariable Long memberId){
         return ResponseEntity.status(MEMBER_FOUND.getStatus())
                 .body(CommonResponse.from(MEMBER_FOUND.getMessage(),memberService.getMember(memberId)));
+    }
+
+    @Operation(summary = "학생 알림 허용", description = "학생의 FCM 알림을 허용합니다.")
+    @PatchMapping("/notification/permit")
+    public ResponseEntity<CommonResponse<Object>> loginMember(@AuthenticationPrincipal UserDetails userDetails,@RequestBody MemberFcmReq memberFcmReq) {
+        Long memberId = Long.parseLong(userDetails.getUsername());
+        memberService.permitFcm(memberId, memberFcmReq.getFcmToken());
+        return ResponseEntity.status(MEMBER_FCM_PERMIT.getStatus())
+                .body(CommonResponse.from(MEMBER_FCM_PERMIT.getMessage()));
+    }
+
+    @Operation(summary = "학생 알림 거부", description = "학생의 FCM 알림을 거부합니다.")
+    @PatchMapping("/notification/deny")
+    public ResponseEntity<CommonResponse<Object>> loginMember(@AuthenticationPrincipal UserDetails userDetails) {
+        Long memberId = Long.parseLong(userDetails.getUsername());
+        memberService.denyFcm(memberId);
+        return ResponseEntity.status(MEMBER_FCM_DENY.getStatus())
+                .body(CommonResponse.from(MEMBER_FCM_DENY.getMessage()));
     }
 }

--- a/src/main/java/com/appcenter/marketplace/domain/member/controller/MemberController.java
+++ b/src/main/java/com/appcenter/marketplace/domain/member/controller/MemberController.java
@@ -37,7 +37,7 @@ public class MemberController {
                 .body(CommonResponse.from(MEMBER_FOUND.getMessage(),memberService.getMember(memberId)));
     }
 
-    @Operation(summary = "학생 알림 허용(FCM 토큰 서버 저장)", description = "FCM 토큰을 저장합니다.")
+    @Operation(summary = "FCM 토큰 저장 API", description = "FCM 토큰을 저장합니다.")
     @PatchMapping("/notification/permit")
     public ResponseEntity<CommonResponse<Object>> loginMember(@AuthenticationPrincipal UserDetails userDetails,@RequestBody MemberFcmReq memberFcmReq) {
         Long memberId = Long.parseLong(userDetails.getUsername());
@@ -46,7 +46,7 @@ public class MemberController {
                 .body(CommonResponse.from(MEMBER_FCM_PERMIT.getMessage()));
     }
 
-    @Operation(summary = "학생 알림 거부(FCM 토큰 삭제)", description = "FCM 토큰을 삭제합니다.")
+    @Operation(summary = "FCM 토큰 삭제 API", description = "FCM 토큰을 삭제합니다.")
     @PatchMapping("/notification/deny")
     public ResponseEntity<CommonResponse<Object>> loginMember(@AuthenticationPrincipal UserDetails userDetails) {
         Long memberId = Long.parseLong(userDetails.getUsername());

--- a/src/main/java/com/appcenter/marketplace/domain/member/controller/MemberController.java
+++ b/src/main/java/com/appcenter/marketplace/domain/member/controller/MemberController.java
@@ -37,7 +37,7 @@ public class MemberController {
                 .body(CommonResponse.from(MEMBER_FOUND.getMessage(),memberService.getMember(memberId)));
     }
 
-    @Operation(summary = "학생 알림 허용", description = "학생의 FCM 알림을 허용합니다.")
+    @Operation(summary = "학생 알림 허용(FCM 토큰 서버 저장)", description = "FCM 토큰을 저장합니다.")
     @PatchMapping("/notification/permit")
     public ResponseEntity<CommonResponse<Object>> loginMember(@AuthenticationPrincipal UserDetails userDetails,@RequestBody MemberFcmReq memberFcmReq) {
         Long memberId = Long.parseLong(userDetails.getUsername());
@@ -46,7 +46,7 @@ public class MemberController {
                 .body(CommonResponse.from(MEMBER_FCM_PERMIT.getMessage()));
     }
 
-    @Operation(summary = "학생 알림 거부", description = "학생의 FCM 알림을 거부합니다.")
+    @Operation(summary = "학생 알림 거부(FCM 토큰 삭제)", description = "FCM 토큰을 삭제합니다.")
     @PatchMapping("/notification/deny")
     public ResponseEntity<CommonResponse<Object>> loginMember(@AuthenticationPrincipal UserDetails userDetails) {
         Long memberId = Long.parseLong(userDetails.getUsername());

--- a/src/main/java/com/appcenter/marketplace/domain/member/dto/req/MemberFcmReq.java
+++ b/src/main/java/com/appcenter/marketplace/domain/member/dto/req/MemberFcmReq.java
@@ -1,0 +1,11 @@
+package com.appcenter.marketplace.domain.member.dto.req;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberFcmReq {
+
+    private String fcmToken;
+}

--- a/src/main/java/com/appcenter/marketplace/domain/member/service/MemberService.java
+++ b/src/main/java/com/appcenter/marketplace/domain/member/service/MemberService.java
@@ -7,4 +7,7 @@ public interface MemberService {
     MemberLoginRes login(MemberLoginReq memberLoginReq);
     MemberLoginRes getMember(Long studentId);
     long resetCheerTickets();
+
+    void permitFcm(Long memberId, String fcmToken);
+    void denyFcm(Long memberId);
 }

--- a/src/main/java/com/appcenter/marketplace/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/member/service/impl/MemberServiceImpl.java
@@ -16,6 +16,7 @@ import static com.appcenter.marketplace.global.common.StatusCode.INVALID_STUDENT
 import static com.appcenter.marketplace.global.common.StatusCode.UNAUTHORIZED_LOGIN_ERROR;
 
 
+@Transactional(readOnly = true)
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -42,7 +43,6 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    @Transactional
     public MemberLoginRes getMember(Long studentId) {
         Member member = findMemberByMemberId(studentId);
         return MemberLoginRes.toDto(member);
@@ -55,12 +55,14 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional
     public void permitFcm(Long memberId, String fcmToken) {
         Member member = findMemberByMemberId(memberId);
         member.permitFcmToken(fcmToken);
     }
 
     @Override
+    @Transactional
     public void denyFcm(Long memberId) {
         Member member = findMemberByMemberId(memberId);
         member.denyFcmToken();

--- a/src/main/java/com/appcenter/marketplace/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/appcenter/marketplace/domain/member/service/impl/MemberServiceImpl.java
@@ -1,15 +1,14 @@
 package com.appcenter.marketplace.domain.member.service.impl;
 
 import com.appcenter.marketplace.domain.member.Member;
-import com.appcenter.marketplace.domain.member.repository.MemberRepository;
 import com.appcenter.marketplace.domain.member.dto.req.MemberLoginReq;
 import com.appcenter.marketplace.domain.member.dto.res.MemberLoginRes;
+import com.appcenter.marketplace.domain.member.repository.MemberRepository;
 import com.appcenter.marketplace.domain.member.service.MemberService;
 import com.appcenter.marketplace.global.exception.CustomException;
 import com.appcenter.marketplace.global.oracleRepository.InuLoginRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,6 +52,18 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     public long resetCheerTickets() {
             return memberRepository.resetCheerTickets();
+    }
+
+    @Override
+    public void permitFcm(Long memberId, String fcmToken) {
+        Member member = findMemberByMemberId(memberId);
+        member.permitFcmToken(fcmToken);
+    }
+
+    @Override
+    public void denyFcm(Long memberId) {
+        Member member = findMemberByMemberId(memberId);
+        member.denyFcmToken();
     }
 
     // 학번 로그인 검증 및 형변환

--- a/src/main/java/com/appcenter/marketplace/global/common/StatusCode.java
+++ b/src/main/java/com/appcenter/marketplace/global/common/StatusCode.java
@@ -36,6 +36,8 @@ public enum StatusCode {
     // Member
     MEMBER_LOGIN_SUCCESS(OK, "로그인에 성공하였습니다."),
     MEMBER_FOUND(OK, "회원 조회 완료"),
+    MEMBER_FCM_PERMIT(OK,"회원 FCM 알림 허용"),
+    MEMBER_FCM_DENY(OK,"회원 FCM 알림 거부"),
 
     // FCM
     FCM_SEND_SUCCESS(OK, "알림 메시지 전송에 성공하였습니다."),

--- a/src/main/java/com/appcenter/marketplace/global/common/StatusCode.java
+++ b/src/main/java/com/appcenter/marketplace/global/common/StatusCode.java
@@ -41,6 +41,9 @@ public enum StatusCode {
 
     // FCM
     FCM_SEND_SUCCESS(OK, "알림 메시지 전송에 성공하였습니다."),
+    FCM_SEND_FAIL(INTERNAL_SERVER_ERROR, "알림 메시지 전송에 실패하였습니다."),
+    FCM_SUBSCRIBE_FAIL(INTERNAL_SERVER_ERROR,"FCM 구독 요청이 실패했습니다."),
+    FCM_UNSUBSCRIBE_FAIL(INTERNAL_SERVER_ERROR,"FCM 구독 해제 요청이 실패했습니다."),
 
 
 

--- a/src/main/java/com/appcenter/marketplace/global/common/StatusCode.java
+++ b/src/main/java/com/appcenter/marketplace/global/common/StatusCode.java
@@ -37,6 +37,9 @@ public enum StatusCode {
     MEMBER_LOGIN_SUCCESS(OK, "로그인에 성공하였습니다."),
     MEMBER_FOUND(OK, "회원 조회 완료"),
 
+    // FCM
+    FCM_SEND_SUCCESS(OK, "알림 메시지 전송에 성공하였습니다."),
+
 
 
     /* 400 BAD_REQUEST : 잘못된 요청 */
@@ -68,8 +71,10 @@ public enum StatusCode {
     /* 409 CONFLICT : 리소스 충돌 */
     COUPON_ALREADY_ISSUED(CONFLICT, "이미 발급된 쿠폰입니다."),
     COUPON_SOLD_OUT(CONFLICT, "쿠폰이 모두 소진되었습니다."),
-    TICKET_SOLD_OUT(CONFLICT, "공감권이 소진되었습니다.");
+    TICKET_SOLD_OUT(CONFLICT, "공감권이 소진되었습니다."),
 
+    /* 503 UNAVAILABLE : 서비스 이용 불가  */
+    FCM_UNAVAILABLE(SERVICE_UNAVAILABLE, "알림 기능을 이용할 수 없습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/appcenter/marketplace/global/config/AsyncConfig.java
+++ b/src/main/java/com/appcenter/marketplace/global/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package com.appcenter.marketplace.global.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "FcmExecutor")
+    public Executor getFcmExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(3);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("Async FcmExecutor ");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/appcenter/marketplace/global/config/FcmConfig.java
+++ b/src/main/java/com/appcenter/marketplace/global/config/FcmConfig.java
@@ -1,0 +1,53 @@
+package com.appcenter.marketplace.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+@Configuration
+public class FcmConfig {
+
+    private final ClassPathResource firebaseResource;
+    private final String projectId;
+
+    public FcmConfig(
+            @Value("${fcm.file_path}") String firebaseFilePath,
+            @Value("${fcm.project_id}") String projectId) {
+
+        this.firebaseResource = new ClassPathResource(firebaseFilePath);
+        this.projectId = projectId;
+    }
+
+    // 빈 생성 전 firebase 초기화
+    @PostConstruct
+    public void init() throws IOException {
+        FirebaseOptions option = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(firebaseResource.getInputStream()))
+                .setProjectId(projectId)
+                .build();
+
+        if (FirebaseApp.getApps().isEmpty()) {
+            FirebaseApp.initializeApp(option);
+        }
+    }
+
+    // fcm 푸시 알림을 보내는 객체
+    @Bean
+    FirebaseMessaging firebaseMessaging() {
+        return FirebaseMessaging.getInstance(firebaseApp());
+    }
+
+    //firebase sdk의 인스턴스 역할
+    @Bean
+    FirebaseApp firebaseApp() {
+        return FirebaseApp.getInstance();
+    }
+}

--- a/src/main/java/com/appcenter/marketplace/global/config/RetryConfig.java
+++ b/src/main/java/com/appcenter/marketplace/global/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.appcenter.marketplace.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}

--- a/src/main/java/com/appcenter/marketplace/global/exception/FcmException.java
+++ b/src/main/java/com/appcenter/marketplace/global/exception/FcmException.java
@@ -1,0 +1,11 @@
+package com.appcenter.marketplace.global.exception;
+
+import com.appcenter.marketplace.global.common.StatusCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class FcmException extends RuntimeException{
+    private final StatusCode statusCode;
+}

--- a/src/main/java/com/appcenter/marketplace/global/fcm/FcmController.java
+++ b/src/main/java/com/appcenter/marketplace/global/fcm/FcmController.java
@@ -12,7 +12,7 @@ import static com.appcenter.marketplace.global.common.StatusCode.MARKET_DELETE;
 @Tag(name = "[알림TEST]", description = "[사장님,관리자] 알림 전송")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/notification")
+@RequestMapping("/api/notifications")
 public class FcmController {
     private final FcmService fcmService;
 

--- a/src/main/java/com/appcenter/marketplace/global/fcm/FcmController.java
+++ b/src/main/java/com/appcenter/marketplace/global/fcm/FcmController.java
@@ -1,6 +1,7 @@
 package com.appcenter.marketplace.global.fcm;
 
 import com.appcenter.marketplace.global.common.CommonResponse;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +22,7 @@ public class FcmController {
 
     @Operation(summary = "[TEST] 개인 알림 전송", description = "개인 회원에게 알림 메시지 전송")
     @PostMapping
-    public ResponseEntity<CommonResponse<Object>> sendFcmMessage(@RequestBody FcmRequest fcmRequest){
+    public ResponseEntity<CommonResponse<Object>> sendFcmMessage(@RequestBody FcmRequest fcmRequest) throws FirebaseMessagingException{
         fcmService.sendFcmMessage(fcmRequest);
         return ResponseEntity
                 .ok(CommonResponse.from(FCM_SEND_SUCCESS.getMessage()));

--- a/src/main/java/com/appcenter/marketplace/global/fcm/FcmController.java
+++ b/src/main/java/com/appcenter/marketplace/global/fcm/FcmController.java
@@ -1,0 +1,26 @@
+package com.appcenter.marketplace.global.fcm;
+
+import com.appcenter.marketplace.global.common.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.appcenter.marketplace.global.common.StatusCode.MARKET_DELETE;
+
+@Tag(name = "[알림TEST]", description = "[사장님,관리자] 알림 전송")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notification")
+public class FcmController {
+    private final FcmService fcmService;
+
+    @Operation(summary = "[TEST] 개인 알림 전송", description = "개인 회원에게 알림 메시지 전송")
+    @PostMapping
+    public ResponseEntity<CommonResponse<Object>> sendFcmMessage(@RequestBody FcmRequest fcmRequest){
+        fcmService.sendFcmMessage(fcmRequest);
+        return ResponseEntity
+                .ok(CommonResponse.from(MARKET_DELETE.getMessage()));
+    }
+}

--- a/src/main/java/com/appcenter/marketplace/global/fcm/FcmController.java
+++ b/src/main/java/com/appcenter/marketplace/global/fcm/FcmController.java
@@ -5,9 +5,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import static com.appcenter.marketplace.global.common.StatusCode.MARKET_DELETE;
+import static com.appcenter.marketplace.global.common.StatusCode.FCM_SEND_SUCCESS;
 
 @Tag(name = "[알림TEST]", description = "[사장님,관리자] 알림 전송")
 @RestController
@@ -21,6 +24,6 @@ public class FcmController {
     public ResponseEntity<CommonResponse<Object>> sendFcmMessage(@RequestBody FcmRequest fcmRequest){
         fcmService.sendFcmMessage(fcmRequest);
         return ResponseEntity
-                .ok(CommonResponse.from(MARKET_DELETE.getMessage()));
+                .ok(CommonResponse.from(FCM_SEND_SUCCESS.getMessage()));
     }
 }

--- a/src/main/java/com/appcenter/marketplace/global/fcm/FcmRequest.java
+++ b/src/main/java/com/appcenter/marketplace/global/fcm/FcmRequest.java
@@ -1,0 +1,21 @@
+package com.appcenter.marketplace.global.fcm;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FcmRequest {
+    Long memberId;
+    String title;
+    String body;
+
+    @Builder
+    public FcmRequest(Long memberId, String title, String body) {
+        this.memberId = memberId;
+        this.title = title;
+        this.body = body;
+    }
+}
+

--- a/src/main/java/com/appcenter/marketplace/global/fcm/FcmService.java
+++ b/src/main/java/com/appcenter/marketplace/global/fcm/FcmService.java
@@ -1,0 +1,48 @@
+package com.appcenter.marketplace.global.fcm;
+
+import com.appcenter.marketplace.domain.member.Member;
+import com.appcenter.marketplace.domain.member.repository.MemberRepository;
+import com.appcenter.marketplace.global.common.StatusCode;
+import com.appcenter.marketplace.global.exception.CustomException;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final MemberRepository memberRepository;
+
+    public void sendFcmMessage(FcmRequest fcmRequest){
+        Optional<Member> member= memberRepository.findById(fcmRequest.memberId);
+
+        if(member.isPresent()){
+            if(member.get().getFcmToken() != null){
+                Notification notification= Notification.builder()
+                        .setTitle(fcmRequest.getTitle())
+                        .setBody(fcmRequest.getBody())
+                        .build();
+
+                Message message= Message.builder()
+                        .setToken(member.get().getFcmToken())
+                        .setNotification(notification)
+                        .build();
+
+                try{
+                    firebaseMessaging.sendAsync(message);
+                } catch (Exception e){
+                    throw new CustomException(StatusCode.FCM_UNAVAILABLE);
+                }
+            }
+        }
+    }
+
+
+}

--- a/src/main/java/com/appcenter/marketplace/global/fcm/FcmService.java
+++ b/src/main/java/com/appcenter/marketplace/global/fcm/FcmService.java
@@ -3,6 +3,7 @@ package com.appcenter.marketplace.global.fcm;
 import com.appcenter.marketplace.domain.member.Member;
 import com.appcenter.marketplace.domain.member.repository.MemberRepository;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +20,7 @@ public class FcmService {
     private final FirebaseMessaging firebaseMessaging;
     private final MemberRepository memberRepository;
 
-    public void sendFcmMessage(FcmRequest fcmRequest){
+    public void sendFcmMessage(FcmRequest fcmRequest) throws FirebaseMessagingException {
         Optional<Member> member= memberRepository.findById(fcmRequest.memberId);
 
         if(member.isPresent()){
@@ -35,7 +36,7 @@ public class FcmService {
                         .build();
 
                 // 비동기 메시지 전송
-                firebaseMessaging.sendAsync(message);
+                firebaseMessaging.send(message);
             }
         }
     }

--- a/src/main/java/com/appcenter/marketplace/global/fcm/FcmService.java
+++ b/src/main/java/com/appcenter/marketplace/global/fcm/FcmService.java
@@ -2,18 +2,17 @@ package com.appcenter.marketplace.global.fcm;
 
 import com.appcenter.marketplace.domain.member.Member;
 import com.appcenter.marketplace.domain.member.repository.MemberRepository;
-import com.appcenter.marketplace.global.common.StatusCode;
-import com.appcenter.marketplace.global.exception.CustomException;
 import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class FcmService {
 
@@ -35,11 +34,8 @@ public class FcmService {
                         .setNotification(notification)
                         .build();
 
-                try{
-                    firebaseMessaging.sendAsync(message);
-                } catch (Exception e){
-                    throw new CustomException(StatusCode.FCM_UNAVAILABLE);
-                }
+                // 비동기 메시지 전송
+                firebaseMessaging.sendAsync(message);
             }
         }
     }

--- a/src/main/java/com/appcenter/marketplace/global/fcm/FcmService.java
+++ b/src/main/java/com/appcenter/marketplace/global/fcm/FcmService.java
@@ -2,15 +2,25 @@ package com.appcenter.marketplace.global.fcm;
 
 import com.appcenter.marketplace.domain.member.Member;
 import com.appcenter.marketplace.domain.member.repository.MemberRepository;
+import com.appcenter.marketplace.global.common.StatusCode;
+import com.appcenter.marketplace.global.exception.CustomException;
+import com.appcenter.marketplace.global.fcm.event.SendNewCouponFcmEvent;
+import com.appcenter.marketplace.global.fcm.event.SubscribeMarketEvent;
+import com.appcenter.marketplace.global.fcm.event.UnSubscribeMarketEvent;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.Collections;
 import java.util.Optional;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
 
 @Service
 @Slf4j
@@ -39,6 +49,88 @@ public class FcmService {
                 firebaseMessaging.send(message);
             }
         }
+    }
+
+    @Async("FcmExecutor")
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void sendNewCouponFcmToSubscriber(SendNewCouponFcmEvent event){
+        Message message = Message.builder()
+                .setNotification(
+                        Notification.builder()
+                                .setTitle(event.getCoupon().getName())
+                                .setBody(event.getCoupon().getDescription())
+                                .build()
+                )
+                .setTopic("market-"+ event.getMarket().getId())
+                .build();
+
+        try{
+            String response= firebaseMessaging.send(message);
+            log.info("메세지 발송 성공: {}", response);
+        } catch (FirebaseMessagingException e){
+            log.error("예외 발생: {}", e.getErrorCode());
+            throw new CustomException(StatusCode.FCM_SEND_FAIL);
+        }
+
+    }
+
+    @Async("FcmExecutor")
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void subscribeMarket(SubscribeMarketEvent event){
+
+        try {
+            FirebaseMessaging
+                    .getInstance()
+                    .subscribeToTopic(Collections.singletonList(event.getMember().getFcmToken())
+                            , ("market-" + event.getMarket().getId().toString()));
+        } catch (FirebaseMessagingException e){
+            throw new CustomException(StatusCode.FCM_SUBSCRIBE_FAIL);
+        }
+
+//        ApiFuture<TopicManagementResponse> apiFuture = FirebaseMessaging
+//                .getInstance()
+//                .subscribeToTopicAsync(Collections.singletonList(event.getMember().getFcmToken())
+//                        ,("market-"+ event.getMarket().getId().toString()));
+//
+//        apiFuture.addListener(() ->{
+//            try{
+//                TopicManagementResponse response = apiFuture.get();
+//                log.info("토픽 구독 성공: {}", response.getSuccessCount());
+//            } catch (ExecutionException | InterruptedException e) {
+//                log.error("토픽 구독 관련 예외 발생: {}", e.getMessage());
+//                throw new CustomException(StatusCode.FCM_SUBSCRIBE_FAIL);
+//            }
+//        }, asyncConfig.getFcmExecutor());
+    }
+
+    @Async("FcmExecutor")
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void unsubscribeMarket(UnSubscribeMarketEvent event) {
+
+        try {
+            FirebaseMessaging
+                    .getInstance()
+                    .unsubscribeFromTopic(Collections.singletonList(event.getMember().getFcmToken())
+                            , ("market-" + event.getMarket().getId().toString()));
+        } catch (FirebaseMessagingException e){
+            throw new CustomException(StatusCode.FCM_UNSUBSCRIBE_FAIL);
+        }
+
+//        ApiFuture<TopicManagementResponse> apiFuture = FirebaseMessaging
+//                .getInstance()
+//                .subscribeToTopicAsync(Collections.singletonList(event.getMember().getFcmToken())
+//                        ,("market-"+ event.getMarket().getId().toString()));
+//
+//
+//        apiFuture.addListener(() ->{
+//            try{
+//                TopicManagementResponse response = apiFuture.get();
+//                log.info("토픽 구독취소 성공: {}", response.getSuccessCount());
+//            } catch (ExecutionException | InterruptedException e) {
+//                log.error("토픽 구독취소 관련 예외 발생: {}", e.getMessage());
+//                throw new CustomException(StatusCode.FCM_UNSUBSCRIBE_FAIL);
+//            }
+//        }, asyncConfig.getFcmExecutor());
     }
 
 

--- a/src/main/java/com/appcenter/marketplace/global/fcm/event/SendNewCouponFcmEvent.java
+++ b/src/main/java/com/appcenter/marketplace/global/fcm/event/SendNewCouponFcmEvent.java
@@ -1,0 +1,16 @@
+package com.appcenter.marketplace.global.fcm.event;
+
+import com.appcenter.marketplace.domain.coupon.Coupon;
+import com.appcenter.marketplace.domain.market.Market;
+import lombok.Getter;
+
+@Getter
+public class SendNewCouponFcmEvent {
+    private final Market market;
+    private final Coupon coupon;
+
+    public SendNewCouponFcmEvent(Market market, Coupon coupon) {
+        this.market = market;
+        this.coupon = coupon;
+    }
+}

--- a/src/main/java/com/appcenter/marketplace/global/fcm/event/SubscribeMarketEvent.java
+++ b/src/main/java/com/appcenter/marketplace/global/fcm/event/SubscribeMarketEvent.java
@@ -1,0 +1,16 @@
+package com.appcenter.marketplace.global.fcm.event;
+
+import com.appcenter.marketplace.domain.market.Market;
+import com.appcenter.marketplace.domain.member.Member;
+import lombok.Getter;
+
+@Getter
+public class SubscribeMarketEvent {
+    private final Member member;
+    private final Market market;
+
+    public SubscribeMarketEvent(Member member, Market market) {
+        this.member = member;
+        this.market = market;
+    }
+}

--- a/src/main/java/com/appcenter/marketplace/global/fcm/event/UnSubscribeMarketEvent.java
+++ b/src/main/java/com/appcenter/marketplace/global/fcm/event/UnSubscribeMarketEvent.java
@@ -1,0 +1,16 @@
+package com.appcenter.marketplace.global.fcm.event;
+
+import com.appcenter.marketplace.domain.market.Market;
+import com.appcenter.marketplace.domain.member.Member;
+import lombok.Getter;
+
+@Getter
+public class UnSubscribeMarketEvent {
+    private final Member member;
+    private final Market market;
+
+    public UnSubscribeMarketEvent(Member member, Market market) {
+        this.member = member;
+        this.market = market;
+    }
+}

--- a/src/test/java/com/appcenter/marketplace/FcmRetryTest.java
+++ b/src/test/java/com/appcenter/marketplace/FcmRetryTest.java
@@ -1,0 +1,110 @@
+package com.appcenter.marketplace;
+
+
+import com.appcenter.marketplace.domain.coupon.Coupon;
+import com.appcenter.marketplace.domain.favorite.repository.FavoriteRepository;
+import com.appcenter.marketplace.domain.market.Market;
+import com.appcenter.marketplace.domain.member.repository.MemberRepository;
+import com.appcenter.marketplace.global.config.RetryConfig;
+import com.appcenter.marketplace.global.exception.FcmException;
+import com.appcenter.marketplace.global.fcm.FcmService;
+import com.appcenter.marketplace.global.fcm.event.SendNewCouponFcmEvent;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {FcmService.class, RetryConfig.class}) // 필요한 Bean만 로드
+public class FcmRetryTest {
+    @MockBean
+    private FirebaseMessaging firebaseMessaging;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private FavoriteRepository favoriteRepository;
+
+    @MockBean
+    private SendNewCouponFcmEvent sendNewCouponFcmEvent;
+
+    @MockBean
+    private FirebaseMessagingException firebaseMessagingException;
+
+    @Autowired
+    private FcmService fcmService;
+
+    @MockBean
+    private Market market; // Market도 Mock
+
+    @MockBean
+    private Coupon coupon; // Coupon도 Mock
+
+
+
+    @Test
+    @DisplayName("FCM 서버 에러 시 최대 3번 재시도 후 Recover 메서드 실행")
+    void testRetry() throws FirebaseMessagingException {
+        // given
+        given(firebaseMessagingException.getMessagingErrorCode()).willReturn(MessagingErrorCode.INTERNAL);
+        given(firebaseMessaging.send(any(Message.class))).willThrow(firebaseMessagingException);
+
+        when(sendNewCouponFcmEvent.getCoupon()).thenReturn(coupon);
+        when(coupon.getName()).thenReturn("New Coupon");
+        when(coupon.getDescription()).thenReturn("Special Discount Coupon");
+
+        when(sendNewCouponFcmEvent.getMarket()).thenReturn(market);
+        when(market.getId()).thenReturn(1L);
+
+//        fcmService.sendNewCouponFcmToSubscriber(sendNewCouponFcmEvent);
+        // when, then
+        assertThatThrownBy(() ->
+                fcmService.sendNewCouponFcmToSubscriber(sendNewCouponFcmEvent))
+                .isInstanceOf(FcmException.class);
+
+        // then
+        // FirebaseMessaging.send() 메서드가 3번 호출되었는지 검증
+        verify(firebaseMessaging, times(3)).send(any(Message.class));
+
+    }
+
+    @Test
+    @DisplayName("재시도 중 정상 응답이 오면 재시도하지 않는다")
+    void testRetryWithSuccessfulResponse() throws FirebaseMessagingException {
+        // given
+
+        given(firebaseMessagingException.getMessagingErrorCode()).willReturn(MessagingErrorCode.INTERNAL);
+        // 첫 번째 호출에서는 예외를 던짐
+        given(firebaseMessaging.send(any(Message.class))).willThrow(firebaseMessagingException)
+                // 두 번째 호출에서는 정상 응답을 반환
+                .willReturn("Success response");
+
+        when(sendNewCouponFcmEvent.getCoupon()).thenReturn(coupon);
+        when(coupon.getName()).thenReturn("New Coupon");
+        when(coupon.getDescription()).thenReturn("Special Discount Coupon");
+
+        when(sendNewCouponFcmEvent.getMarket()).thenReturn(market);
+        when(market.getId()).thenReturn(1L);
+
+        // when
+        fcmService.sendNewCouponFcmToSubscriber(sendNewCouponFcmEvent);
+
+        // then
+        // 정상 응답이 들어오면 재시도가 멈추어야 하므로 총 두 번 호출됨
+        verify(firebaseMessaging, times(2)).send(any(Message.class));
+    }
+}

--- a/src/test/java/com/appcenter/marketplace/FcmServiceTest.java
+++ b/src/test/java/com/appcenter/marketplace/FcmServiceTest.java
@@ -1,0 +1,77 @@
+package com.appcenter.marketplace;
+
+import com.appcenter.marketplace.domain.coupon.Coupon;
+import com.appcenter.marketplace.domain.coupon.dto.req.CouponReq;
+import com.appcenter.marketplace.domain.coupon.repository.CouponRepository;
+import com.appcenter.marketplace.domain.coupon.service.impl.CouponOwnerServiceImpl;
+import com.appcenter.marketplace.domain.market.Market;
+import com.appcenter.marketplace.domain.market.repository.MarketRepository;
+import com.appcenter.marketplace.global.fcm.event.SendNewCouponFcmEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class FcmServiceTest {
+
+    @InjectMocks
+    private CouponOwnerServiceImpl couponOwnerService;
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @Mock
+    private MarketRepository marketRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private Market market; // Market도 Mock
+
+    @Mock
+    private Coupon coupon; // Coupon도 Mock
+
+    @Test
+    @DisplayName("트랜잭션이 성공적으로 끝나면 이벤트가 발행된다")
+    void testEventPublishedAfterCommit() {
+        // Given
+        CouponReq couponReq = mock(CouponReq.class);
+
+        when(marketRepository.findById(anyLong())).thenReturn(Optional.of(market));
+        when(couponReq.ofCreate(market)).thenReturn(coupon); // Coupon 객체 생성도 Mock 처리
+        when(couponRepository.save(any(Coupon.class))).thenReturn(coupon);
+
+        // When
+        couponOwnerService.createCoupon(couponReq, 1L);
+
+        // Then
+        verify(eventPublisher, times(1)).publishEvent(any(SendNewCouponFcmEvent.class));
+    }
+
+    @Test
+    @DisplayName("예외 발생으로 트랜잭션 롤백 시 이벤트가 발행되지 않는다")
+    void testEventNotPublishedOnRollback() {
+        // Given
+        CouponReq couponReq = mock(CouponReq.class);
+
+        when(marketRepository.findById(anyLong())).thenReturn(Optional.of(market));
+        when(couponReq.ofCreate(market)).thenReturn(coupon);
+        when(couponRepository.save(any(Coupon.class))).thenThrow(new RuntimeException("DB Error")); // 예외 발생
+
+        // When / Then
+        assertThrows(RuntimeException.class, () -> couponOwnerService.createCoupon(couponReq, 1L));
+
+        // 이벤트가 발행되지 않았는지 검증
+        verify(eventPublisher, never()).publishEvent(any(SendNewCouponFcmEvent.class));
+    }
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 구현
- [ ] 문서화
- [ ] 리팩토링
- [ ] 이슈해결(오류해결)
- [x] 의존성, 환경 변수, 빌드 관련 환경설정 


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
<br>
close #115 
<br>


## 💻작업사항
필요시 실행결과 스크린샷 첨부
<br>
<br>


## 💡작성한 이슈 외에 작업한 사항
- 구현한 기능
- [x] 멤버 테이블 FCM 토큰 컬럼 추가 
- [x] FCM 토큰 저장 API
- [x] FCM 토큰 삭제 API
- [x] 매장 찜/찜 취소를 통한 FCM 토픽 구독/구독 취소 구현
- [x] 매장의 신규 쿠폰 발행 시 해당 매장 토픽 구독자에게 푸시 알림 구현
- [x] FCM 외부 API 요청 기능을 비동기 이벤트 처리(서비스 의존성 제거,순서 보장)
- [x] 비동기 작업 예외 발생 시 Retry를 통한 가용성 확보
- [x] 매장 찜/찜취소 작업 후, 구독,구독취소 예외 발생 시 Retry 최대 횟수 후 Recover 작업을 통해 찜/찜 취소 철회 기능 구현
 
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
